### PR TITLE
__init__.py: remove non-existing names from __all__

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -317,8 +317,6 @@ __all__ = [
     "cum_count",
     "cum_fold",
     "cum_reduce",
-    "cumfold",
-    "cumreduce",
     "date",
     "datetime",
     "duration",


### PR DESCRIPTION
`from polars import *` used to raise the following error before this change.
```
AttributeError: module 'polars' has no attribute 'cumfold'. Did you mean: 'cum_fold'?
```